### PR TITLE
Session/3 StatefulWidget のライフサイクル

### DIFF
--- a/lib/launch_view.dart
+++ b/lib/launch_view.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_training/screen.dart';
+
+class LaunchView extends StatefulWidget {
+  const LaunchView({super.key});
+
+  @override
+  State<LaunchView> createState() => _LaunchViewState();
+}
+
+class _LaunchViewState extends State<LaunchView> {
+  Future<void> transition() async {
+    await SchedulerBinding.instance.endOfFrame;
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    if (!context.mounted) {
+      return;
+    }
+
+    await Navigator.pushNamed(context, Screen.weatherForecast.route);
+
+    unawaited(transition());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(transition());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.green,
+      body: Container(),
+    );
+  }
+}

--- a/lib/launch_view.dart
+++ b/lib/launch_view.dart
@@ -34,9 +34,6 @@ class _LaunchViewState extends State<LaunchView> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.green,
-      body: Container(),
-    );
+    return const ColoredBox(color: Colors.green);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/launch_view.dart';
+import 'package:flutter_training/screen.dart';
 import 'package:flutter_training/weather_forecast_view.dart';
 
 void main() {
@@ -10,8 +12,12 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: WeatherForecastView(),
+    return MaterialApp(
+      home: const LaunchView(),
+      routes: {
+        Screen.launch.route: (context) => const LaunchView(),
+        Screen.weatherForecast.route: (context) => const WeatherForecastView(),
+      },
     );
   }
 }

--- a/lib/screen.dart
+++ b/lib/screen.dart
@@ -1,0 +1,10 @@
+enum Screen {
+  launch(route: '/launch'),
+  weatherForecast(route: '/weather_forecast');
+
+  const Screen({
+    required this.route,
+  });
+
+  final String route;
+}

--- a/lib/weather_forecast_view.dart
+++ b/lib/weather_forecast_view.dart
@@ -42,7 +42,7 @@ class _WeatherForecastViewState extends State<WeatherForecastView> {
                   children: [
                     const SizedBox(height: 80),
                     CommonTextButton(
-                      onClosePressed: () async {
+                      onClosePressed: () {
                         Navigator.pop(context);
                       },
                       onReloadPressed: () {

--- a/lib/weather_forecast_view.dart
+++ b/lib/weather_forecast_view.dart
@@ -42,7 +42,9 @@ class _WeatherForecastViewState extends State<WeatherForecastView> {
                   children: [
                     const SizedBox(height: 80),
                     CommonTextButton(
-                      onClosePressed: () {},
+                      onClosePressed: () async {
+                        Navigator.pop(context);
+                      },
                       onReloadPressed: () {
                         setState(() {
                           _weatherCondition = _weatherService.fetchWeather();


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] [StatefulWidget](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は [Colors.green](https://api.flutter.dev/flutter/material/Colors/green-constant.html) に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual(iOS) | actual(Android) |
|----------|--------|--------|
| ![](https://raw.githubusercontent.com/yumemi-inc/flutter-training-template/main/docs/sessions/images/lifecycle/demo.gif)      | <video src="https://github.com/KaitoKudou/flutter_training-kudo/assets/40165303/9b707c4b-2e43-4e04-aaea-c1b8ef0d4189">    |  <video src="https://github.com/KaitoKudou/flutter_training-kudo/assets/40165303/777eee7d-4c2b-4267-9e53-7966e612d82d">    |