### PR TITLE
Session/5 API のエラーハンドリング

### DIFF
--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -6,26 +6,28 @@ class WeatherService {
 
   final YumemiWeather _client;
 
-  Result fetchWeather() {
+  Result<WeatherCondition, String> fetchWeather() {
     try {
       final condition = _client.fetchThrowsWeather('tokyo');
       return Success(WeatherCondition.from(condition));
     } on YumemiWeatherError catch (e) {
       return Failure(e.toExceptionMessage);
+    } on Exception catch (_) {
+      return const Failure('例外エラーが発生しました');
     }
   }
 }
 
-sealed class Result {}
+sealed class Result<S, E> {}
 
-class Success implements Result {
+class Success<S, E> implements Result<S, E> {
   const Success(this.value);
-  final WeatherCondition value;
+  final S value;
 }
 
-class Failure implements Result {
+class Failure<S, E> implements Result<S, E> {
   const Failure(this.exceptionMessage);
-  final String exceptionMessage;
+  final E exceptionMessage;
 }
 
 extension YumemiWeatherErrorException on YumemiWeatherError {

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -6,9 +6,31 @@ class WeatherService {
 
   final YumemiWeather _client;
 
-  WeatherCondition fetchWeather() {
-    final condition = _client.fetchSimpleWeather();
-
-    return WeatherCondition.from(condition);
+  Result fetchWeather() {
+    try {
+      final condition = _client.fetchThrowsWeather('tokyo');
+      return Success(WeatherCondition.from(condition));
+    } on YumemiWeatherError catch (e) {
+      return Failure(e.toExceptionMessage);
+    }
   }
+}
+
+sealed class Result {}
+
+class Success implements Result {
+  const Success(this.value);
+  final WeatherCondition value;
+}
+
+class Failure implements Result {
+  const Failure(this.exceptionMessage);
+  final String exceptionMessage;
+}
+
+extension YumemiWeatherErrorException on YumemiWeatherError {
+  String get toExceptionMessage => switch (this) {
+        YumemiWeatherError.invalidParameter => '無効なパラメータが入力されました',
+        YumemiWeatherError.unknown => '不明なエラーです',
+      };
 }

--- a/lib/view/weather_forecast_view.dart
+++ b/lib/view/weather_forecast_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/model/weather_condition.dart';
 import 'package:flutter_training/service/weather_service.dart';
@@ -20,6 +22,23 @@ class WeatherForecastView extends StatefulWidget {
 
 class _WeatherForecastViewState extends State<WeatherForecastView> {
   WeatherCondition? _weatherCondition;
+
+  Future<void> _showErrorExceptionDialog(String exceptionMessage) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          content: Text(exceptionMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -46,9 +65,18 @@ class _WeatherForecastViewState extends State<WeatherForecastView> {
                         Navigator.pop(context);
                       },
                       onReloadPressed: () {
-                        setState(() {
-                          _weatherCondition = _weatherService.fetchWeather();
-                        });
+                        switch (_weatherService.fetchWeather()) {
+                          case Success(value: final value):
+                            setState(() {
+                              _weatherCondition = value;
+                            });
+                          case Failure(
+                              exceptionMessage: final exceptionMessage
+                            ):
+                            unawaited(
+                              _showErrorExceptionDialog(exceptionMessage),
+                            );
+                        }
                       },
                     ),
                   ],

--- a/lib/view/weather_forecast_view.dart
+++ b/lib/view/weather_forecast_view.dart
@@ -23,7 +23,7 @@ class WeatherForecastView extends StatefulWidget {
 class _WeatherForecastViewState extends State<WeatherForecastView> {
   WeatherCondition? _weatherCondition;
 
-  Future<void> _showErrorExceptionDialog(String exceptionMessage) {
+  Future<void> _showErrorDialog(String exceptionMessage) {
     return showDialog<void>(
       context: context,
       builder: (context) {
@@ -74,7 +74,7 @@ class _WeatherForecastViewState extends State<WeatherForecastView> {
                               exceptionMessage: final exceptionMessage
                             ):
                             unawaited(
-                              _showErrorExceptionDialog(exceptionMessage),
+                              _showErrorDialog(exceptionMessage),
                             );
                         }
                       },


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
  - [x] メッセージの内容は自由
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual(iOS) | actual(Android) |
|----------|--------|--------|
| ![demo]      | <video src = "https://github.com/KaitoKudou/flutter_training-kudo/assets/40165303/46554451-1c7e-4d86-a0bc-48df04b181f4">    | <video src = "https://github.com/KaitoKudou/flutter_training-kudo/assets/40165303/c7552eea-ab50-4152-91d6-f764c4f26c2a">    |

[demo]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/error/demo.gif?raw=true
